### PR TITLE
Rename Calculate $ to Settle, default money/pt to 0, tidy leaderboards

### DIFF
--- a/src/routes/LeaderboardsPage.tsx
+++ b/src/routes/LeaderboardsPage.tsx
@@ -103,7 +103,9 @@ export function LeaderboardsPage() {
   }, [rawPlayerRows, playerSort]);
 
   const familyRows = useMemo(() => {
-    const rows = [...rawFamilyRows];
+    const rows = rawFamilyRows.filter(
+      (row) => row.roundsWon + row.roundsLost > 0,
+    );
     const dir = familySort.dir === "asc" ? 1 : -1;
     rows.sort((a, b) => {
       let cmp = 0;


### PR DESCRIPTION
## Summary
- Rename the end-of-game "Calculate $" button to "Settle" since most games don't involve money transactions.
- Default money-per-point for new games to 0 cents (was 20).
- Remove Game W-L and Game W-L (%) columns from both player and family leaderboards, leaving only Round W-L and Round %.
- Hide families with zero rounds played from the family leaderboard in each filtered view.

## Test plan
- [x] `npx tsc -b` passes
- [x] `npm test` — all 31 tests pass
- [ ] Manually verify the new game form defaults money/pt to 0
- [ ] Manually verify the "Settle" button triggers the existing settlement flow
- [ ] Manually verify leaderboards no longer show Game W-L columns and hide families with 0 rounds per filter

https://claude.ai/code/session_01G8NnHQbqto2iDHs73FMZy2