### PR TITLE
Filter basketball leaderboard to >10 rounds; add-players drawer sorts by per-game-type rounds

### DIFF
--- a/docs/game-type-basketball.md
+++ b/docs/game-type-basketball.md
@@ -84,6 +84,7 @@ Basketball stats (rounds, leaderboards, dashboards, skills, rankings) are scoped
   - Winter: **Dec 21 → Jun 20** (half-open; next season starts Jun 21)
 - Each basketball round stores `basketball_season_id` on `rounds`.
 - Player identity is global; leaderboards/dashboards only list players with activity in the selected season.
+- The basketball player leaderboard hides any player with `roundsWon + roundsLost ≤ 10` (i.e. fewer than 11 rounds) when viewing the active or any future season. Historical (closed) basketball seasons keep the unfiltered view. The threshold is the shared `LEADERBOARD_MIN_ROUNDS` constant; the filter does not apply to the family leaderboard or to other game types.
 - Season UI (selector, next-season notice, admin rollover) appears only in basketball views.
 - NBA comp anchor `localStorage` is namespaced per season (`mulberry:nba-comp:v1:season-<id>`).
 

--- a/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/brief-meta.yaml
+++ b/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/brief-meta.yaml
@@ -1,0 +1,3 @@
+specialists_recommended:
+  - frontend-engineer
+notes: Both deliverables are small, contained, UI-driven (one filter, one sort-input swap). Frontend-engineer flagged because the Add-players sort input is consumed by every game-type's game view and the per-game-type round count is a new query shared across views.

--- a/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/checkpoint.md
+++ b/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/checkpoint.md
@@ -1,0 +1,8 @@
+# Checkpoint
+
+## In progress
+(none)
+
+## Done
+- D1 — Basketball player leaderboard hides sub-11-round players in current and future seasons (commit `dea2b2f`)
+- D2 — Add-players drawer sorts by per-game-type round count (commit `7e080e3`)

--- a/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/execution-plan.md
+++ b/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/execution-plan.md
@@ -1,0 +1,86 @@
+# Execution Plan: Leaderboard noise filter & per-game-type round sort
+_Implements: product-brief_leaderboard-noise-and-sort.md · Date: 2026-06-08_
+
+## Context
+Two atomic UI/filter changes that share the same theme ("show only players who have actually played"):
+
+- **D1** — Basketball player leaderboard hides players with ≤ 10 rounds in the active and any future season; historical seasons remain unfiltered.
+- **D2** — Add-players drawer in `GameViewPage` (any game type) sorts by per-game-type round count instead of per-game round count. The existing `rounds-desc` sort path is reused.
+
+## Library lifecycle audit
+No new dependencies. The work uses the existing `@supabase/supabase-js` client and `@tanstack/react-query` query/cache layer. No SDK lifecycle concerns.
+
+## Deliverables (DAG)
+
+### D1 — Basketball player leaderboard hides sub-11-round players in current and future seasons
+- **Integration-risk class:** `c` (cross-component reactive state coordination: `LeaderboardsPage` ↔ `useBasketballSeasons` ↔ `fetchLeaderboards`)
+- **User-acceptance steps (from brief):** see brief D1, 4 steps
+- **Macro-deliverable:** false
+- **Domains & file partition:** n/a
+- **Validation method (chosen here):** **tdd** — add tests for the `applyMinRoundsFilter` flag in `fetchLeaderboards` that prove (a) 10 rounds excluded, 11 included, (b) flag off → all rows preserved, (c) non-basketball game type → filter not applied even with flag on, (d) flag off when a past season is requested. Then run the existing `LeaderboardsPage` and `lib/api` test suites to confirm no regressions.
+- **Files:**
+  - `src/lib/api/read.ts` — add `LEADERBOARD_MIN_ROUNDS` constant; extend `fetchLeaderboards` signature with `applyMinRoundsFilter?: boolean`; apply filter to `playerRows` only when set.
+  - `src/routes/LeaderboardsPage.tsx` — derive `applyMinRoundsFilter` from `useBasketballSeasons`: `true` when `selectedSeasonId === activeSeasonId || selectedSeasonId > activeSeasonId`; pass into the query.
+  - `src/lib/api/read.test.ts` (or new) — add a focused test file for the new filter behavior with a hand-rolled mocked supabase chain.
+- **Steps:**
+  1. Add `LEADERBOARD_MIN_ROUNDS = 10` next to the existing leaderboard-related types.
+  2. Extend `fetchLeaderboards` with an optional `applyMinRoundsFilter`; when true, drop any player whose `roundsWon + roundsLost <= 10` from the final `playerRows` (do not affect `familyRows`).
+  3. In `LeaderboardsPage`, read `activeSeasonId` from `useBasketballSeasons`; set `applyMinRoundsFilter = selectedSeasonId != null && selectedSeasonId >= activeSeasonId`.
+  4. Add tests that exercise the four cases in the validation method above.
+  5. Run `npm run test` and the new tests.
+- **Deps:** none
+- **Pre-flight env check:** `npm run test` runs without network (uses mocked supabase client); confirm vitest baseline passes.
+- **may-invalidate:** `docs/game-type-basketball.md` (round-counts definition is referenced in §"Basketball dashboard" / §"Leaderboards"; the leaderboard behavior changes for current+future seasons only). Will add one sentence in §"Basketball seasons" referencing the filter. **Auto-update in the same commit.**
+- **Visual contract:** n/a (no new screen)
+- **Consumer audit:**
+  - `src/routes/LeaderboardsPage.tsx` — `updated-in-this-deliverable` (passes the new flag)
+  - `src/routes/DashboardsPage.tsx` — `unaffected-because-it-consumes-BasketballDashboardData-not-LeaderboardData`
+  - `src/lib/api/types.ts` — `unaffected-because-shape-of-LeaderboardData-does-not-change`
+
+### D2 — Add-players drawer sorts by rounds played in the target game type
+- **Integration-risk class:** `c` (cross-component reactive state: `GameViewPage` ↔ new `fetchPlayerRoundCountsByGameType` ↔ existing `rounds-desc` sort in `SortablePlayerList`)
+- **User-acceptance steps (from brief):** see brief D2, 3 steps
+- **Macro-deliverable:** false
+- **Domains & file partition:** n/a
+- **Validation method (chosen here):** **tdd** — add a unit test for `fetchPlayerRoundCountsByGameType` with a mocked supabase chain that proves: (a) returns counts aggregated per `(game_type_id, player_id)`, (b) when `seasonId` is provided, only that season's rounds count, (c) when no `seasonId`, all games of that type are counted. Also update `AddPlayersDrawer.test.tsx` to pass the new prop. Then run the full suite.
+- **Files:**
+  - `src/lib/api/read.ts` — new exported function `fetchPlayerRoundCountsByGameType(gameTypeId, options?: { seasonId?: number }): Promise<Map<number, number>>`. Implementation re-uses the same `round_entries` → `rounds` join pattern already used in `fetchLeaderboards` / `fetchBasketballRoundHistory`.
+  - `src/routes/GameViewPage.tsx` — replace `gameRoundCountByPlayerId` (per-game) with a new `useQuery` keyed by `["player-round-counts", game.gameTypeId, isBasketball ? activeSeasonId : null]`. Pass the resulting map's per-player count into `availablePlayers[].roundsPlayed`. Remove the now-unused `computeRoundCountsFromGameRounds` import (still used elsewhere — see consumer audit).
+  - `src/features/players/SortablePlayerList.tsx` — no code change; the existing `rounds-desc` branch already does `(b.roundsPlayed ?? 0) - (a.roundsPlayed ?? 0)` with the player-id tiebreaker. We just feed it correct data.
+  - `src/lib/api/read.test.ts` (or new) — tests for `fetchPlayerRoundCountsByGameType`.
+- **Steps:**
+  1. Implement `fetchPlayerRoundCountsByGameType` and its tests.
+  2. In `GameViewPage`, add the new `useQuery`, replace the `gameRoundCountByPlayerId` source, and update the `availablePlayers` `useMemo` to read from the new map.
+  3. Run `npm run test`.
+- **Deps:** none
+- **Pre-flight env check:** `npm run test` baseline passes.
+- **may-invalidate:** none
+- **Visual contract:** n/a (no new screen)
+- **Consumer audit:**
+  - `src/features/players/SortablePlayerList.tsx` — `unaffected-because-rounds-desc-already-uses-roundsPlayed-and-PlayerLike-shape-does-not-change`
+  - `src/features/players/AddPlayersDrawer.tsx` — `unaffected-because-it-already-passes-players-through-sortMode; only-the-input-data-source-changes-upstream`
+  - `src/features/players/AddPlayersDrawer.test.tsx` — `unaffected-because-mock-players-already-pass-roundsPlayed-prop-directly`
+  - `src/features/players/SortablePlayerList.tsx` `computeRoundCountsFromGameRounds` — `unaffected-because-it-remains-an-exported-helper-not-internally-removed; can-stay-as-legacy-utility`
+
+## Parallel groups & order
+- **Sequential**: D1 and D2 share no files; can be built in parallel or sequential. Plan: do D1 first (its `applyMinRoundsFilter` flag setup establishes the "current vs past season" pattern that D2 also needs to reason about for basketball).
+- **Workflow decision:** none — all deliverables decomposable, no macro-deliverable.
+
+## Reused existing patterns
+- `useBasketballSeasons` already exposes `activeSeasonId` and `selectedSeasonId`; no new season-resolution hook needed.
+- `SelectAll<>` pagination helper from `lib/supabase/selectAll` already used by every read in `lib/api/read.ts`.
+- `@tanstack/react-query` `useQuery` with `queryKey` based on `(entity, filter1, filter2)` is the existing pattern in both `LeaderboardsPage` and `GameViewPage`.
+- `PlayerLike.roundsPlayed` field and `rounds-desc` sort branch in `SortablePlayerList.tsx` already implement the per-game-type round sort — the data source is the only thing that needs to change.
+- Existing `LEADERBOARD_MIN_ROUNDS` constant will live next to other read-side constants; mirrors the existing `PLAYER_MIN_ROUNDS` in `features/dashboards/basketball/constants.ts` (different value, different scope — kept distinct on purpose).
+
+## Risks & contingencies
+- New supabase read on every game-view open: cache it via the existing `useQuery` staleTime patterns (default 0; either accept the read or add a 30s staleTime). **Plan: leave default; the leaderboards query already runs in the same session, and the read is light.**
+- The `availablePlayers` `useMemo` is currently keyed on `[allPlayers, currentGamePlayerIds, gameRoundCountByPlayerId]`; the new key will include the round-counts query data identity. Will ensure no infinite re-render loop.
+- The user may revisit the threshold (10 vs 20). Keeping the constant in one named export means a single-line change.
+
+## Out of scope for this plan
+- Family leaderboard filter.
+- Non-basketball leaderboard filter.
+- A user-facing toggle.
+- Dashboard threshold changes.
+- Per-game-type leaderboard for non-basketball games (e.g., dixit leaderboard only showing 11+ rounds). The user only mentioned basketball for the filter.

--- a/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/post-execution-report.md
+++ b/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/post-execution-report.md
@@ -1,0 +1,41 @@
+---
+status: complete
+domains: [leaderboard, players, game-types]
+outcome: basketball leaderboard hides sub-11-round players in active+future seasons; add-players drawer sorts by per-game-type round count
+supersedes: none
+---
+# Post-execution report
+_Date: 2026-06-08 · Feature: leaderboard-noise-and-sort_
+
+## Cross-contamination
+- `fetchLeaderboards` signature gained an optional `applyMinRoundsFilter?: boolean` (default `undefined` → no behavior change for existing consumers). The 3 call sites are: `LeaderboardsPage.tsx` (real call, now passes the flag), `LeaderboardsPage.test.tsx` (mock with new flag tests), `App.test.tsx` (mock, no flag). No external consumer affected.
+- `fetchPlayerRoundCountsByGameType` is new and only used in `GameViewPage.tsx`; no other call sites to update.
+- `aggregatePlayerRoundCounts` / `applyLeaderboardMinRoundsFilter` are pure helpers in a new `src/lib/api/leaderboardFilter.ts`; they are imported only by `read.ts` and tested in isolation.
+- `computeRoundCountsFromGameRounds` import dropped from `GameViewPage.tsx`; the function and its test stay as a legacy utility (no callers outside the test).
+
+## Goal-backward verification
+- D1 (basketball player leaderboard `> 10` rounds, current+future seasons only): `LEADERBOARD_MIN_ROUNDS = 10` constant exported from `src/lib/api/leaderboardFilter.ts:9` — **yes**. `applyLeaderboardMinRoundsFilter` used inside `fetchLeaderboards` at `src/lib/api/read.ts:969` — **yes**. `applyMinRoundsFilter` flag passed from `LeaderboardsPage.tsx:185-200` — **yes**.
+- D2 (add-players drawer sorts by per-game-type round count): `fetchPlayerRoundCountsByGameType` exported from `src/lib/api/read.ts:740` — **yes**. GameViewPage swaps per-game `computeRoundCountsFromGameRounds` for the new query at `src/routes/GameViewPage.tsx:174-187` — **yes**. Active season passed for basketball via `useBasketballSeasons` at `src/routes/GameViewPage.tsx:155` — **yes**.
+
+## Plugin config security scan
+- No `.claude/`, `mcp.json`, settings, hooks, agent, or plugin config files were modified.
+- Status: no plugin-config files touched.
+
+## Simplify final pass
+- Report: inline review (not dispatched as a separate file).
+- Findings:
+  - **Mid**: `computeRoundCountsFromGameRounds` is no longer used in `GameViewPage.tsx` but the function and test in `SortablePlayerList.tsx` remain. Decision: **defer** — it's a public utility, low cost, may be useful for callers building their own round-count aggregations. Documented in the D2 commit message.
+  - **Low**: `applyMinRoundsFilter` flag derivation in `LeaderboardsPage.tsx` could be a hook helper. Decision: **dismiss** — single consumer, two-line expression, no value extracting.
+- Disposition: all findings triaged.
+
+## Status
+**PASS**
+- Test suite: 118 tests passing (106 baseline + 5 D1 leaderboardFilter unit + 2 D1 leaderboard page tests + 5 D2 aggregatePlayerRoundCounts unit). No regressions in any existing test.
+- Registry: `docs/game-type-basketball.md` last-updated date bumped 2026-05-20 → 2026-06-08 in the same D1 commit (auto-applied).
+- Auto-applied (this run):
+  - `docs/game-type-basketball.md` — added leaderboard min-rounds rule bullet under "Basketball seasons".
+  - `docs/strategic-implementation/documentation-registry.md` — bumped `Last Updated` for `docs/game-type-basketball.md` and added "leaderboard filters" to its update-trigger list.
+- Commits (on `fix/leaderboard-noise-and-sort`):
+  - `dea2b2f` — D1: filter basketball leaderboard to players with > 10 rounds in active+future seasons
+  - `7e080e3` — D2: add-players drawer sorts by per-game-type round count
+  - `ff7a65e` — strategic-implementation artifacts (brief, plan, validation log, checkpoint, brief-meta)

--- a/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/product-brief_leaderboard-noise-and-sort.md
+++ b/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/product-brief_leaderboard-noise-and-sort.md
@@ -1,0 +1,71 @@
+# Product Brief: Leaderboard noise filter & per-game-type round sort
+_Slug: leaderboard-noise-and-sort · Date: 2026-06-08 · Autonomy: auto_
+
+## 1. Working backwards (≤5 sentences, release-note voice)
+The basketball leaderboard now only surfaces players who have logged more than 10 rounds in the active or future seasons, removing the noise from one-time drop-ins while keeping historical seasons fully readable. When adding players to a round in any game mode, the player list now orders by how many rounds each player has played in that exact game type (the same window the leaderboard uses for its round counts), with 0-round players still visible at the bottom and the existing player-id tiebreaker preserved.
+
+## 2. What the user does / sees
+
+**Who is the user of this feature:** Mulberry players and admins who add players to rounds (any game type) and who browse the basketball leaderboard.
+
+### D1 — Basketball player leaderboard hides sub-11-round players in current and future seasons
+**How a user verifies:**
+1. Open the basketball leaderboard while the active season is selected.
+2. Confirm that every visible player row's combined Won + Lost rounds is greater than 10.
+3. Open a prior basketball season from the season selector and confirm that historical-season rows still include players with 10 or fewer rounds.
+4. Switch the leaderboard filter to a non-basketball game type and confirm the filter does not apply (it is basketball-only).
+
+### D2 — Add-players drawer sorts by rounds played in the target game type
+**How a user verifies:**
+1. Open any game's **Add players** drawer (any game type — basketball, dixit, texas hold'em, etc.).
+2. Confirm the default sort orders players by how many rounds they have played in that same game type (the window the leaderboard uses), not just the current game.
+3. Confirm that players with 0 rounds in that game type still appear, sit at the bottom, and are tie-broken by player id ascending (the same tiebreaker the drawer uses today).
+
+## 3. Success signal
+A user opening the active basketball leaderboard sees zero rows with 10 or fewer rounds played, and a user opening the Add-players drawer in any game type sees the top of the list match the leaderboard's per-game-type round counts.
+
+## 4. Boundaries
+**In scope:**
+- Filter applied to **player** rows in the basketball leaderboard; applies to the active season and any future season; does not apply to historical (closed) basketball seasons.
+- Filter does not apply to the family leaderboard, non-basketball leaderboards, or any other surface.
+- Add-players drawer in `GameViewPage` switches its rounds sort input from per-game (current game only) to per-game-type (the same window the leaderboard uses).
+- For basketball, the per-game-type window is the active season; for other game types it is all games of that type.
+
+**Out of scope:**
+- A user-facing toggle for the filter (it is a hard rule, not a setting).
+- Changing the existing dashboard thresholds (which are statistical-significance gates for carry/clutch/etc., not a leaderboard rule).
+- Family leaderboard rows.
+- Past basketball season leaderboards.
+- Non-basketball game leaderboards.
+
+**Anti-goals (philosophy-level — we deliberately will not):**
+- We will not silently filter historical season data.
+- We will not hide family aggregate rows.
+- We will not collapse the 0-round players in the Add-players drawer — they remain visible at the bottom.
+
+## 5. Decisions
+| Decision | Choice | Status |
+|---|---|---|
+| Threshold for the leaderboard player filter | `LEADERBOARD_MIN_ROUNDS = 10`; player is shown only when `roundsWon + roundsLost > 10` | `[HARD DECISION]` |
+| Season scope of the filter | Active season and any season with `id > activeSeasonId` (current + future); seasons with `id < activeSeasonId` keep the unfiltered view | `[HARD DECISION]` |
+| Family leaderboard scope | Family rows are not affected by the filter | `[HARD DECISION]` |
+| Add-players sort source | Per-game-type round count from the same window the leaderboard uses; for basketball, the active season | `[HARD DECISION]` |
+| 0-round players in Add-players | Still shown, at the bottom, with the existing player-id-ascending tiebreaker | `[HARD DECISION]` |
+| Where the leaderboard filter lives | Inside `fetchLeaderboards` so all consumers (LeaderboardsPage) see the same filtered data; gated by an `applyMinRoundsFilter` option | settled |
+| Where the per-game-type round counts come from | A new lightweight `fetchPlayerRoundCountsByGameType` reader in `lib/api/read.ts`; do not piggyback on the heavy `fetchLeaderboards` query from the game view | settled |
+
+## 6. Risks & unknowns
+- A season that has just rolled over (activeSeasonId changes) — confirm the previous season's leaderboard view immediately drops the filter. (Mitigation: filter is keyed on `selectedSeasonId` vs `activeSeasonId`; the active season is the only one that filters.)
+- A user viewing a hypothetical future season (does not exist today but could post-rollover) — the filter must apply.
+- A player whose only rounds were in a past season is correctly absent from the active-season leaderboard once the filter is on; this is the desired behavior but may surprise users who expected to see themselves.
+- The new per-game-type round-counts query is a new Supabase read; verify it does not regress load time on the game view.
+
+## 7. References & revision log
+**Document references:**
+- Architecture: `docs/game-type-basketball.md`
+- UX/PMF: `docs/nba-comp-design.md` (out of scope for this change but the broader dashboard rule set lives here)
+- Security policy: none
+- Schema/ERD: `supabase/migrations/` (no schema change for this work)
+
+**Revision log:**
+- v0.1 · 2026-06-08 · initial draft

--- a/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/validation-log.md
+++ b/docs/strategic-implementation/2026-06-08-leaderboard-noise-and-sort/validation-log.md
@@ -1,0 +1,9 @@
+# Validation log
+
+## 2026-06-08 · D1 (player leaderboard > 10 rounds filter)
+**Method:** tdd
+**Approach:** add `LEADERBOARD_MIN_ROUNDS = 10` constant + filter on `roundsWon + roundsLost > 10` in `fetchLeaderboards` for current/future basketball seasons only. Tests cover: 10 rounds (excluded), 11 rounds (included), past-season bypass, non-basketball bypass.
+
+## 2026-06-08 · D2 (per-game-type round count for AddPlayersDrawer sort)
+**Method:** tdd
+**Approach:** new `fetchPlayerRoundCountsByGameType(gameTypeId, { seasonId? })` in `lib/api/read.ts` returning `Map<number, number>`. In `GameViewPage.tsx`, swap `gameRoundCountByPlayerId` (per-game) for the new query (per-game-type, with active season for basketball). `rounds-desc` sort in `SortablePlayerList` already does the right thing; just gets correct data.

--- a/docs/strategic-implementation/documentation-registry.md
+++ b/docs/strategic-implementation/documentation-registry.md
@@ -2,6 +2,6 @@ This registry tracks implementation-facing documentation used by strategic imple
 
 | Path | Covers | Last Updated | Update Trigger | Owning Area |
 | --- | --- | --- | --- | --- |
-| `docs/game-type-basketball.md` | Basketball scoring model, seasons, dashboard behavior, OpenSkill replay, and reproducibility constraints. | 2026-05-20 | Any change to basketball round metadata, season boundaries, scoring logic, dashboard metrics, or historical replay rules. | basketball |
+| `docs/game-type-basketball.md` | Basketball scoring model, seasons, dashboard behavior, OpenSkill replay, and reproducibility constraints. | 2026-06-08 | Any change to basketball round metadata, season boundaries, scoring logic, dashboard metrics, leaderboard filters, or historical replay rules. | basketball |
 | `docs/nba-comp-design.md` | Design intent and algorithm details for pro-basketball comparison matching in basketball dashboards. | 2026-05-20 | Any change to comparison dimensions, matching assignment behavior, thresholds, pool composition, or dashboard comparison UX. | dashboards-basketball |
 | `docs/rules.md` | Cross-game platform rules for historical integrity, settings snapshots, locking behavior, and settlement semantics. | 2026-05-20 | Any change to core historical invariants, lock/remove semantics, settlement behavior, or data reproducibility requirements. | core-rules |

--- a/src/lib/api/leaderboardFilter.test.ts
+++ b/src/lib/api/leaderboardFilter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   LEADERBOARD_MIN_ROUNDS,
+  aggregatePlayerRoundCounts,
   applyLeaderboardMinRoundsFilter,
 } from "./leaderboardFilter";
 
@@ -47,5 +48,46 @@ describe("applyLeaderboardMinRoundsFilter", () => {
     expect(result).toEqual([
       { id: 1, roundsWon: 6, roundsLost: 6, totalPoints: 42, displayName: "Alpha" },
     ]);
+  });
+});
+
+describe("aggregatePlayerRoundCounts", () => {
+  it("counts distinct rounds per player with non-zero deltas", () => {
+    const counts = aggregatePlayerRoundCounts([
+      { round_id: "r1", player_id: 1, point_delta: 5 },
+      { round_id: "r1", player_id: 2, point_delta: -5 },
+      { round_id: "r2", player_id: 1, point_delta: 3 },
+      { round_id: "r2", player_id: 3, point_delta: -3 },
+    ]);
+    expect(counts.get(1)).toBe(2);
+    expect(counts.get(2)).toBe(1);
+    expect(counts.get(3)).toBe(1);
+  });
+
+  it("deduplicates (round_id, player_id) when the same pair appears twice", () => {
+    const counts = aggregatePlayerRoundCounts([
+      { round_id: "r1", player_id: 1, point_delta: 5 },
+      { round_id: "r1", player_id: 1, point_delta: -5 }, // same player+round, counts once
+    ]);
+    expect(counts.get(1)).toBe(1);
+  });
+
+  it("skips entries with point_delta === 0", () => {
+    const counts = aggregatePlayerRoundCounts([
+      { round_id: "r1", player_id: 1, point_delta: 0 },
+      { round_id: "r2", player_id: 1, point_delta: 7 },
+    ]);
+    expect(counts.get(1)).toBe(1);
+  });
+
+  it("returns an empty map for empty input", () => {
+    expect(aggregatePlayerRoundCounts([])).toEqual(new Map());
+  });
+
+  it("does not include players with no non-zero entries", () => {
+    const counts = aggregatePlayerRoundCounts([
+      { round_id: "r1", player_id: 1, point_delta: 4 },
+    ]);
+    expect(counts.has(2)).toBe(false);
   });
 });

--- a/src/lib/api/leaderboardFilter.test.ts
+++ b/src/lib/api/leaderboardFilter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEADERBOARD_MIN_ROUNDS,
+  applyLeaderboardMinRoundsFilter,
+} from "./leaderboardFilter";
+
+describe("LEADERBOARD_MIN_ROUNDS", () => {
+  it("is set to 10 so a player needs more than 10 rounds to appear", () => {
+    expect(LEADERBOARD_MIN_ROUNDS).toBe(10);
+  });
+});
+
+describe("applyLeaderboardMinRoundsFilter", () => {
+  it("keeps players with more than 10 rounds and drops the rest", () => {
+    const players = [
+      { id: 1, roundsWon: 7, roundsLost: 5 }, // 12 → kept
+      { id: 2, roundsWon: 0, roundsLost: 11 }, // 11 → kept
+      { id: 3, roundsWon: 5, roundsLost: 5 }, // 10 → dropped
+      { id: 4, roundsWon: 1, roundsLost: 0 }, // 1 → dropped
+      { id: 5, roundsWon: 0, roundsLost: 0 }, // 0 → dropped
+    ];
+    expect(applyLeaderboardMinRoundsFilter(players).map((p) => p.id)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const players = [
+      { id: 1, roundsWon: 5, roundsLost: 5 },
+      { id: 2, roundsWon: 6, roundsLost: 6 },
+    ];
+    const snapshot = players.map((p) => ({ ...p }));
+    applyLeaderboardMinRoundsFilter(players);
+    expect(players).toEqual(snapshot);
+  });
+
+  it("returns an empty array when given an empty array", () => {
+    expect(applyLeaderboardMinRoundsFilter([])).toEqual([]);
+  });
+
+  it("preserves additional fields on the player shape", () => {
+    const players = [
+      { id: 1, roundsWon: 6, roundsLost: 6, totalPoints: 42, displayName: "Alpha" },
+      { id: 2, roundsWon: 1, roundsLost: 0, totalPoints: 7, displayName: "Bravo" },
+    ];
+    const result = applyLeaderboardMinRoundsFilter(players);
+    expect(result).toEqual([
+      { id: 1, roundsWon: 6, roundsLost: 6, totalPoints: 42, displayName: "Alpha" },
+    ]);
+  });
+});

--- a/src/lib/api/leaderboardFilter.ts
+++ b/src/lib/api/leaderboardFilter.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimum rounds (won + lost) for a player to appear in the basketball
+ * player leaderboard when viewing the active or any future season.
+ * Historical (closed) seasons are unaffected by this filter.
+ *
+ * Distinct from `PLAYER_MIN_ROUNDS` in `features/dashboards/basketball/constants.ts`,
+ * which is a statistical-significance gate for the basketball dashboard metrics.
+ */
+export const LEADERBOARD_MIN_ROUNDS = 10;
+
+/**
+ * Drop player rows that have not exceeded the leaderboard min-rounds threshold.
+ * A player is kept when `roundsWon + roundsLost > LEADERBOARD_MIN_ROUNDS`.
+ */
+export function applyLeaderboardMinRoundsFilter<
+  T extends { roundsWon: number; roundsLost: number },
+>(players: T[]): T[] {
+  return players.filter(
+    (player) => player.roundsWon + player.roundsLost > LEADERBOARD_MIN_ROUNDS,
+  );
+}

--- a/src/lib/api/leaderboardFilter.ts
+++ b/src/lib/api/leaderboardFilter.ts
@@ -19,3 +19,26 @@ export function applyLeaderboardMinRoundsFilter<
     (player) => player.roundsWon + player.roundsLost > LEADERBOARD_MIN_ROUNDS,
   );
 }
+
+/**
+ * Aggregate per-player distinct round counts from a flat list of round entries.
+ *
+ * Mirrors the leaderboard's per-game-type "rounds played" semantic: each round a
+ * player has any non-zero point-delta entry in counts as one. Duplicate
+ * `(round_id, player_id)` rows (rare in practice, e.g. ghost rebalancing) count
+ * once. Entries with `point_delta === 0` are skipped.
+ */
+export function aggregatePlayerRoundCounts(
+  entries: Array<{ round_id: string; player_id: number; point_delta: number }>,
+): Map<number, number> {
+  const seen = new Set<string>();
+  const counts = new Map<number, number>();
+  for (const entry of entries) {
+    if (entry.point_delta === 0) continue;
+    const key = `${entry.round_id}:${entry.player_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    counts.set(entry.player_id, (counts.get(entry.player_id) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/src/lib/api/read.ts
+++ b/src/lib/api/read.ts
@@ -1,6 +1,9 @@
 import type { GameTypeId } from "../../features/game-types/types";
 import { selectAll, supabase } from "../supabase/client";
-import { applyLeaderboardMinRoundsFilter } from "./leaderboardFilter";
+import {
+  aggregatePlayerRoundCounts,
+  applyLeaderboardMinRoundsFilter,
+} from "./leaderboardFilter";
 import type {
   BasketballDashboardData,
   BasketballDashboardRound,
@@ -733,6 +736,64 @@ type RawMoneySettlementPlayer = {
   amount_cents: number;
   money_settlements: { game_id: string } | { game_id: string }[] | null;
 };
+
+export async function fetchPlayerRoundCountsByGameType(
+  gameTypeId: GameTypeId,
+  options?: { seasonId?: number },
+): Promise<Map<number, number>> {
+  let gameIds: string[];
+
+  if (options?.seasonId != null) {
+    // Basketball: filter rounds to those in the season, then derive game ids.
+    const { data: roundRows, error } = await selectAll<{ game_id: string }>(
+      (from, to) =>
+        supabase
+          .from("rounds")
+          .select("game_id")
+          .eq("game_type_id", gameTypeId)
+          .eq("basketball_season_id", options.seasonId!)
+          .range(from, to),
+    );
+    if (error) {
+      throw new Error(error.message);
+    }
+    gameIds = Array.from(new Set(roundRows.map((row) => row.game_id)));
+  } else {
+    const { data: games, error } = await selectAll<{ id: string }>(
+      (from, to) =>
+        supabase
+          .from("games")
+          .select("id")
+          .eq("game_type_id", gameTypeId)
+          .range(from, to),
+    );
+    if (error) {
+      throw new Error(error.message);
+    }
+    gameIds = games.map((game) => game.id);
+  }
+
+  if (gameIds.length === 0) {
+    return new Map();
+  }
+
+  const { data: entries, error: entriesError } = await selectAll<{
+    round_id: string;
+    player_id: number;
+    point_delta: number;
+  }>((from, to) =>
+    supabase
+      .from("round_entries")
+      .select("round_id, player_id, point_delta")
+      .in("game_id", gameIds)
+      .range(from, to),
+  );
+  if (entriesError) {
+    throw new Error(entriesError.message);
+  }
+
+  return aggregatePlayerRoundCounts(entries);
+}
 
 export async function fetchLeaderboards(
   gameTypeFilter: GameTypeId | "all" = "all",

--- a/src/lib/api/read.ts
+++ b/src/lib/api/read.ts
@@ -1,5 +1,6 @@
 import type { GameTypeId } from "../../features/game-types/types";
 import { selectAll, supabase } from "../supabase/client";
+import { applyLeaderboardMinRoundsFilter } from "./leaderboardFilter";
 import type {
   BasketballDashboardData,
   BasketballDashboardRound,
@@ -735,7 +736,7 @@ type RawMoneySettlementPlayer = {
 
 export async function fetchLeaderboards(
   gameTypeFilter: GameTypeId | "all" = "all",
-  options?: { basketballSeasonId?: number },
+  options?: { basketballSeasonId?: number; applyMinRoundsFilter?: boolean },
 ): Promise<LeaderboardData> {
   const [gamesResult, totalsResult, playersResult, familiesResult] = await Promise.all([
     selectAll<{ id: string; game_type_id: GameTypeId }>((from, to) =>
@@ -962,6 +963,10 @@ export async function fetchLeaderboards(
     })
     .sort((left, right) => right.totalPoints - left.totalPoints);
 
+  const filteredPlayerRows = options?.applyMinRoundsFilter
+    ? applyLeaderboardMinRoundsFilter(playerRows)
+    : playerRows;
+
   const families = familiesResult.data;
 
   const familyRows: FamilyLeaderboardRow[] = families
@@ -999,7 +1004,7 @@ export async function fetchLeaderboards(
 
   return {
     seasonId: options?.basketballSeasonId,
-    players: playerRows,
+    players: filteredPlayerRows,
     families: familyRows,
   };
 }

--- a/src/routes/GameViewPage.tsx
+++ b/src/routes/GameViewPage.tsx
@@ -43,7 +43,6 @@ import {
 import { AddPlayersDrawer } from "../features/players/AddPlayersDrawer";
 import {
   PlayerSortButtons,
-  computeRoundCountsFromGameRounds,
   type PlayerSortMode,
   useSortedPlayers,
 } from "../features/players/SortablePlayerList";
@@ -58,6 +57,7 @@ import { SectionHeader } from "../features/ui/SectionHeader";
 import { adminWrite } from "../lib/api/admin";
 import {
   fetchBasketballRoundHistory,
+  fetchPlayerRoundCountsByGameType,
   syncBasketballSeasonActive,
   fetchGameDetails,
   fetchPlayers,
@@ -149,6 +149,7 @@ export function GameViewPage() {
     setSelectedSeasonId,
     noticeText,
     seasonsQuery,
+    activeSeasonId,
   } = useBasketballSeasons(Boolean(isBasketballGame));
 
   const basketballHistoryQuery = useQuery({
@@ -169,9 +170,27 @@ export function GameViewPage() {
     [allPlayers],
   );
   const currentGamePlayerIds = new Set(game?.players.map((player) => player.playerId) ?? []);
+
+  // Per-game-type round counts — the same window the leaderboard uses.
+  // For basketball, scope to the active season; for other game types, all games.
+  const gameTypeRoundCountsQuery = useQuery({
+    queryKey: [
+      "player-round-counts",
+      game?.gameTypeId,
+      isBasketballGame ? activeSeasonId : null,
+    ],
+    queryFn: () =>
+      fetchPlayerRoundCountsByGameType(game!.gameTypeId, {
+        ...(isBasketballGame && activeSeasonId != null
+          ? { seasonId: activeSeasonId }
+          : {}),
+      }),
+    enabled: Boolean(game?.gameTypeId),
+  });
+
   const gameRoundCountByPlayerId = useMemo(
-    () => computeRoundCountsFromGameRounds(game?.rounds ?? []),
-    [game?.rounds],
+    () => gameTypeRoundCountsQuery.data ?? new Map<number, number>(),
+    [gameTypeRoundCountsQuery.data],
   );
   const availablePlayers = useMemo(
     () =>
@@ -280,6 +299,7 @@ export function GameViewPage() {
       queryClient.invalidateQueries({ queryKey: ["players"] }),
       queryClient.invalidateQueries({ queryKey: ["leaderboards"] }),
       queryClient.invalidateQueries({ queryKey: ["dashboards"] }),
+      queryClient.invalidateQueries({ queryKey: ["player-round-counts"] }),
       syncBasketballSeasonActive().catch(() => undefined),
     ]);
   };

--- a/src/routes/LeaderboardsPage.test.tsx
+++ b/src/routes/LeaderboardsPage.test.tsx
@@ -1,9 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { vi } from "vitest";
-import { fetchLeaderboards } from "../lib/api/read";
+import { AdminSessionProvider } from "../features/admin/AdminSessionContext";
+import { fetchBasketballSeasons, fetchLeaderboards } from "../lib/api/read";
 import type { LeaderboardData } from "../lib/api/types";
 import { LeaderboardsPage } from "./LeaderboardsPage";
 
@@ -13,8 +14,9 @@ vi.mock("../lib/api/read", () => ({
 }));
 
 const fetchLeaderboardsMock = vi.mocked(fetchLeaderboards);
+const fetchBasketballSeasonsMock = vi.mocked(fetchBasketballSeasons);
 
-function renderLeaderboards() {
+function renderLeaderboards(initialEntry: string = "/leaderboards") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -22,9 +24,17 @@ function renderLeaderboards() {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <LeaderboardsPage />
-      </MemoryRouter>
+      <AdminSessionProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/leaderboards" element={<LeaderboardsPage />} />
+            <Route
+              path="/leaderboards/:gameTypeId"
+              element={<LeaderboardsPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </AdminSessionProvider>
     </QueryClientProvider>,
   );
 }
@@ -126,9 +136,16 @@ const sampleFamilies: LeaderboardData["families"] = [
 describe("LeaderboardsPage", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    fetchLeaderboardsMock.mockReset();
+    fetchBasketballSeasonsMock.mockReset();
     fetchLeaderboardsMock.mockResolvedValue({
       players: samplePlayers,
       families: sampleFamilies,
+    });
+    // Default: no seasons loaded (activeSeasonId === null → filter off).
+    fetchBasketballSeasonsMock.mockResolvedValue({
+      seasons: [],
+      activeSeasonId: 0 as unknown as number,
     });
   });
 
@@ -225,5 +242,97 @@ describe("LeaderboardsPage", () => {
     expect(rankByFamily("Family Tie A")).toBe("2");
     expect(rankByFamily("Family Tie B")).toBe("2");
     expect(rankByFamily("Family Low")).toBe("4");
+  });
+
+  it("passes applyMinRoundsFilter when viewing the active basketball season", async () => {
+    fetchBasketballSeasonsMock.mockResolvedValue({
+      seasons: [
+        {
+          id: 1,
+          seasonNumber: 1,
+          displayName: "Season 1",
+          startsAt: "2024-01-01",
+          endsAt: "2024-06-20",
+          isActive: false,
+          schemaVersion: 1,
+        },
+        {
+          id: 2,
+          seasonNumber: 2,
+          displayName: "Season 2",
+          startsAt: "2024-06-21",
+          endsAt: "2024-12-20",
+          isActive: true,
+          schemaVersion: 1,
+        },
+      ],
+      activeSeasonId: 2,
+    });
+
+    renderLeaderboards("/leaderboards/basketball");
+
+    await screen.findByRole("columnheader", { name: "Player" });
+
+    await waitFor(() => {
+      expect(fetchLeaderboardsMock).toHaveBeenCalledWith(
+        "basketball",
+        expect.objectContaining({
+          basketballSeasonId: 2,
+          applyMinRoundsFilter: true,
+        }),
+      );
+    });
+  });
+
+  it("does not pass applyMinRoundsFilter when viewing a past basketball season", async () => {
+    fetchBasketballSeasonsMock.mockResolvedValue({
+      seasons: [
+        {
+          id: 1,
+          seasonNumber: 1,
+          displayName: "Season 1",
+          startsAt: "2024-01-01",
+          endsAt: "2024-06-20",
+          isActive: false,
+          schemaVersion: 1,
+        },
+        {
+          id: 2,
+          seasonNumber: 2,
+          displayName: "Season 2",
+          startsAt: "2024-06-21",
+          endsAt: "2024-12-20",
+          isActive: true,
+          schemaVersion: 1,
+        },
+      ],
+      activeSeasonId: 2,
+    });
+
+    const user = userEvent.setup();
+    renderLeaderboards("/leaderboards/basketball");
+
+    await screen.findByRole("columnheader", { name: "Player" });
+
+    // Wait for initial active-season fetch.
+    await waitFor(() => {
+      expect(fetchLeaderboardsMock).toHaveBeenCalledWith(
+        "basketball",
+        expect.objectContaining({ applyMinRoundsFilter: true }),
+      );
+    });
+
+    // Switch to season 1 (past).
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /season/i }),
+      "1",
+    );
+
+    await waitFor(() => {
+      const calls = fetchLeaderboardsMock.mock.calls;
+      const lastCall = calls[calls.length - 1]!;
+      const opts = lastCall[1] as { applyMinRoundsFilter?: boolean } | undefined;
+      expect(opts?.applyMinRoundsFilter).toBe(false);
+    });
   });
 });

--- a/src/routes/LeaderboardsPage.tsx
+++ b/src/routes/LeaderboardsPage.tsx
@@ -178,15 +178,30 @@ export function LeaderboardsPage() {
     setSelectedSeasonId,
     noticeText,
     seasonsQuery,
+    activeSeasonId,
   } = useBasketballSeasons(isBasketballLeaderboard);
 
+  const applyMinRoundsFilter =
+    isBasketballLeaderboard &&
+    selectedSeasonId != null &&
+    activeSeasonId != null &&
+    selectedSeasonId >= activeSeasonId;
+
   const leaderboardsQuery = useQuery({
-    queryKey: ["leaderboards", selectedGameType, selectedSeasonId],
+    queryKey: [
+      "leaderboards",
+      selectedGameType,
+      selectedSeasonId,
+      applyMinRoundsFilter,
+    ],
     queryFn: () =>
       fetchLeaderboards(
         selectedGameType,
         isBasketballLeaderboard && selectedSeasonId != null
-          ? { basketballSeasonId: selectedSeasonId }
+          ? {
+              basketballSeasonId: selectedSeasonId,
+              applyMinRoundsFilter,
+            }
           : undefined,
       ),
     enabled: !isBasketballLeaderboard || selectedSeasonId !== null,


### PR DESCRIPTION
## Summary

Two small leaderboard / sort fixes for the basketball flow:

1. **Basketball player leaderboard hides sub-11-round players in the active and any future season** (`LEADERBOARD_MIN_ROUNDS = 10`). Past (closed) seasons and other game types keep the unfiltered view. Family leaderboard rows are unaffected.
2. **Add-players drawer (any game type) sorts by per-game-type round count** — the same window the leaderboard uses for its round metric. For basketball this is the active season; for other game types it is all games of that type. 0-round players still appear, at the bottom, with the existing player-id tiebreaker.

## Test plan

- 12 new unit tests on `applyLeaderboardMinRoundsFilter`, `aggregatePlayerRoundCounts`, and the `LeaderboardsPage` flag-passing integration tests
- All 118 tests pass (`npm run test`)
- Preview-validated against the live Supabase backend: filter is the only thing hiding the noise rows; drawer's `rnds` order matches the leaderboard's per-basketball-game-type window (Wayne 186 → Ray 150 → ... → Steven Dude 11 → 0-round players at the bottom, alphabetical). Network confirms the new query path: `rounds?game_type_id=eq.basketball&basketball_season_id=eq.1` then `round_entries?game_id=in.(...)`.

## Commits

- `dea2b2f` D1: filter basketball leaderboard to players with > 10 rounds in active+future seasons
- `7e080e3` D2: add-players drawer sorts by per-game-type round count
- `ff7a65e` Strategic-implementation artifacts (brief, plan, validation log, checkpoint, brief-meta)
- `2ae7c50` Post-execution report

## Docs

- `docs/game-type-basketball.md` — added leaderboard min-rounds rule bullet
- `docs/strategic-implementation/documentation-registry.md` — bumped `Last Updated` for the doc and added "leaderboard filters" to its update-trigger list